### PR TITLE
좋아요 수 동시성 문제 해결

### DIFF
--- a/src/main/java/com/dku/council/domain/like/repository/LikeMemoryRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/LikeMemoryRepository.java
@@ -68,6 +68,22 @@ public interface LikeMemoryRepository {
     void setLikeCount(Long elementId, int count, LikeTarget target);
 
     /**
+     * 좋아요 개수 1 증가
+     *
+     * @param elementId 요소 ID
+     * @param target    요소 타입
+     */
+    void increaseLikeCount(Long elementId, LikeTarget target);
+
+    /**
+     * 좋아요 개수 1 감소
+     *
+     * @param elementId 요소 ID
+     * @param target    요소 타입
+     */
+    void decreaseLikeCount(Long elementId, LikeTarget target);
+
+    /**
      * 캐싱된 모든 '좋아요' 데이터중에서 특정 유저의 것들만 가져오고, 모두 삭제한다.
      *
      * @param userId 사용자 ID

--- a/src/main/java/com/dku/council/domain/like/repository/impl/LikeRedisRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/impl/LikeRedisRepository.java
@@ -80,6 +80,18 @@ public class LikeRedisRepository implements LikeMemoryRepository {
     }
 
     @Override
+    public void increaseLikeCount(Long elementId, LikeTarget target) {
+        String key = combine(RedisKeys.LIKE_COUNT_KEY, target, elementId);
+        redisTemplate.opsForValue().increment(key);
+    }
+
+    @Override
+    public void decreaseLikeCount(Long elementId, LikeTarget target) {
+        String key = combine(RedisKeys.LIKE_COUNT_KEY, target, elementId);
+        redisTemplate.opsForValue().decrement(key);
+    }
+
+    @Override
     public List<LikeEntry> getAllLikesAndClear(Long userId, LikeTarget target) {
         String key = combine(RedisKeys.LIKE_KEY, target, userId);
         Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);

--- a/src/main/java/com/dku/council/domain/like/service/impl/CachedLikeServiceImpl.java
+++ b/src/main/java/com/dku/council/domain/like/service/impl/CachedLikeServiceImpl.java
@@ -28,18 +28,20 @@ public class CachedLikeServiceImpl implements LikeService {
 
 
     @Override
+    @Transactional(readOnly = true)
     public void like(Long elementId, Long userId, LikeTarget target) {
         if (!isLiked(elementId, userId, target)) {
             memoryRepository.like(elementId, userId, target);
-            memoryRepository.setLikeCount(elementId, getCountOfLikes(elementId, target) + 1, target); // TODO 동시성 문제
+            memoryRepository.increaseLikeCount(elementId, target);
         }
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void cancelLike(Long elementId, Long userId, LikeTarget target) {
         if (isLiked(elementId, userId, target)) {
             memoryRepository.cancelLike(elementId, userId, target);
-            memoryRepository.setLikeCount(elementId, getCountOfLikes(elementId, target) - 1, target);
+            memoryRepository.decreaseLikeCount(elementId, target);
         }
     }
 

--- a/src/test/java/com/dku/council/domain/like/repository/impl/LikeRedisRepositoryTest.java
+++ b/src/test/java/com/dku/council/domain/like/repository/impl/LikeRedisRepositoryTest.java
@@ -170,6 +170,34 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
     }
 
     @Test
+    @DisplayName("좋아요 수 증가")
+    void increaseLikes() {
+        // given
+        PostLikeKey key = new PostLikeKey();
+        key.setCount(redisTemplate, "10");
+
+        // when
+        repository.increaseLikeCount(key.elementId, POST);
+
+        // then
+        assertThat(key.getCount(redisTemplate)).isEqualTo("11");
+    }
+
+    @Test
+    @DisplayName("좋아요 수 감소")
+    void decreaseLikes() {
+        // given
+        PostLikeKey key = new PostLikeKey();
+        key.setCount(redisTemplate, "10");
+
+        // when
+        repository.decreaseLikeCount(key.elementId, POST);
+
+        // then
+        assertThat(key.getCount(redisTemplate)).isEqualTo("9");
+    }
+
+    @Test
     @DisplayName("캐싱된 모든 좋아요 가져오고 삭제가 잘 되는지?")
     void getAllPostLikesAndClear() {
         // given

--- a/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceConcurrencyTest.java
+++ b/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceConcurrencyTest.java
@@ -1,5 +1,6 @@
 package com.dku.council.domain.like.service;
 
+import com.dku.council.domain.like.repository.LikeMemoryRepository;
 import com.dku.council.domain.like.service.impl.CachedLikeServiceImpl;
 import com.dku.council.domain.post.model.entity.Post;
 import com.dku.council.domain.post.repository.post.NewsRepository;
@@ -10,6 +11,7 @@ import com.dku.council.domain.user.repository.UserRepository;
 import com.dku.council.mock.MajorMock;
 import com.dku.council.mock.NewsMock;
 import com.dku.council.mock.UserMock;
+import com.dku.council.util.FullIntegrationTest;
 import com.dku.council.util.base.AbstractContainerRedisTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,13 +27,16 @@ import static com.dku.council.domain.like.model.LikeTarget.POST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-//@FullIntegrationTest todo
+@FullIntegrationTest
 class CachedLikeServiceConcurrencyTest extends AbstractContainerRedisTest {
 
     private static final int THREAD_COUNT = 100;
 
     @Autowired
     private CachedLikeServiceImpl service;
+
+    @Autowired
+    private LikeMemoryRepository memoryRepository;
 
     @Autowired
     private UserRepository userRepository;
@@ -78,5 +83,6 @@ class CachedLikeServiceConcurrencyTest extends AbstractContainerRedisTest {
 
         // then
         assertThat(service.getCountOfLikes(post.getId(), POST)).isEqualTo(THREAD_COUNT);
+        assertThat(memoryRepository.getAllLikesAndClear(POST).size()).isEqualTo(THREAD_COUNT);
     }
 }

--- a/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceConcurrencyTest.java
+++ b/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceConcurrencyTest.java
@@ -1,0 +1,82 @@
+package com.dku.council.domain.like.service;
+
+import com.dku.council.domain.like.service.impl.CachedLikeServiceImpl;
+import com.dku.council.domain.post.model.entity.Post;
+import com.dku.council.domain.post.repository.post.NewsRepository;
+import com.dku.council.domain.user.model.entity.Major;
+import com.dku.council.domain.user.model.entity.User;
+import com.dku.council.domain.user.repository.MajorRepository;
+import com.dku.council.domain.user.repository.UserRepository;
+import com.dku.council.mock.MajorMock;
+import com.dku.council.mock.NewsMock;
+import com.dku.council.mock.UserMock;
+import com.dku.council.util.base.AbstractContainerRedisTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static com.dku.council.domain.like.model.LikeTarget.POST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+//@FullIntegrationTest todo
+class CachedLikeServiceConcurrencyTest extends AbstractContainerRedisTest {
+
+    private static final int THREAD_COUNT = 100;
+
+    @Autowired
+    private CachedLikeServiceImpl service;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MajorRepository majorRepository;
+
+    @Autowired
+    private NewsRepository newsRepository;
+
+    private Post post;
+    private List<User> users;
+
+
+    @BeforeEach
+    void setUp() {
+        Major major = majorRepository.save(MajorMock.create());
+        users = new ArrayList<>(THREAD_COUNT);
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            User user = UserMock.create(major);
+            user = userRepository.save(user);
+            users.add(user);
+        }
+
+        post = newsRepository.save(NewsMock.create(users.get(0)));
+    }
+
+    @Test
+    @DisplayName("동시에 k건 이상의 like를 추가하면, k건만큼 like가 추가되어야 한다.")
+    void likeNoCached() throws InterruptedException {
+        // given
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+        // when
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final int index = i;
+            new Thread(() -> {
+                service.like(post.getId(), users.get(index).getId(), POST);
+                latch.countDown();
+            }).start();
+        }
+        latch.await();
+
+        // then
+        assertThat(service.getCountOfLikes(post.getId(), POST)).isEqualTo(THREAD_COUNT);
+    }
+}

--- a/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceImplTest.java
+++ b/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceImplTest.java
@@ -47,32 +47,14 @@ class CachedLikeServiceImplTest {
     private CachedLikeServiceImpl service;
 
     @Test
-    @DisplayName("좋아요 - 캐시에 count가 없는 경우")
+    @DisplayName("좋아요")
     void likeNoCached() {
-        // given
-        when(memoryRepository.getCachedLikeCount(10L, POST)).thenReturn(-1);
-        when(persistenceRepository.countByElementIdAndTarget(10L, POST)).thenReturn(5);
-
         // when
         service.like(10L, 10L, POST);
 
         // then
         verify(memoryRepository).like(10L, 10L, POST);
-        verify(memoryRepository).setLikeCount(any(), eq(6), eq(POST));
-    }
-
-    @Test
-    @DisplayName("좋아요 - 캐시에 count가 있는 경우")
-    void likeCached() {
-        // given
-        when(memoryRepository.getCachedLikeCount(10L, POST)).thenReturn(5);
-
-        // when
-        service.like(10L, 10L, POST);
-
-        // then
-        verify(memoryRepository).like(10L, 10L, POST);
-        verify(memoryRepository).setLikeCount(any(), eq(6), eq(POST));
+        verify(memoryRepository).increaseLikeCount(10L, POST);
     }
 
     @Test
@@ -90,11 +72,9 @@ class CachedLikeServiceImplTest {
     }
 
     @Test
-    @DisplayName("좋아요 취소 - 캐시에 count가 없는 경우")
+    @DisplayName("좋아요 취소")
     void cancelLikeNoCached() {
         // given
-        when(memoryRepository.getCachedLikeCount(10L, POST)).thenReturn(-1);
-        when(persistenceRepository.countByElementIdAndTarget(10L, POST)).thenReturn(5);
         when(memoryRepository.isLiked(10L, 10L, POST)).thenReturn(true);
 
         // when
@@ -102,22 +82,7 @@ class CachedLikeServiceImplTest {
 
         // then
         verify(memoryRepository).cancelLike(10L, 10L, POST);
-        verify(memoryRepository).setLikeCount(any(), eq(4), eq(POST));
-    }
-
-    @Test
-    @DisplayName("좋아요 취소 - 캐시에 count가 있는 경우")
-    void cancelLikeCached() {
-        // given
-        when(memoryRepository.getCachedLikeCount(10L, POST)).thenReturn(5);
-        when(memoryRepository.isLiked(10L, 10L, POST)).thenReturn(true);
-
-        // when
-        service.cancelLike(10L, 10L, POST);
-
-        // then
-        verify(memoryRepository).cancelLike(10L, 10L, POST);
-        verify(memoryRepository).setLikeCount(any(), eq(4), eq(POST));
+        verify(memoryRepository).decreaseLikeCount(10L, POST);
     }
 
     @Test


### PR DESCRIPTION
동시성 문제로 인해 좋아요 수가 일부 무시되는 문제가 있습니다.
좋아요 수를 1 올리거나 내릴 때, 2개였던 연산을 1개로 줄여 동시성 문제를 해결했습니다.

Redis에서 1개 연산은 동시성 문제가 발생하지 않습니다. (Atomic)