### PR TITLE
버스 timeout 추가

### DIFF
--- a/src/main/java/com/dku/council/domain/bus/model/dto/ResponseBusArrivalDto.java
+++ b/src/main/java/com/dku/council/domain/bus/model/dto/ResponseBusArrivalDto.java
@@ -1,5 +1,6 @@
 package com.dku.council.domain.bus.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -7,11 +8,14 @@ import lombok.RequiredArgsConstructor;
 import java.time.Instant;
 import java.util.List;
 
+import static com.dku.council.global.config.jackson.JacksonDateTimeFormatter.DATE_TIME_FORMAT_PATTERN;
+
 @Getter
 @RequiredArgsConstructor
 public class ResponseBusArrivalDto {
 
     @Schema(description = "도착 시간이 계산된 시각", example = "2022-03-01 11:31:11")
+    @JsonFormat(pattern = DATE_TIME_FORMAT_PATTERN, timezone = "Asia/Seoul")
     private final Instant capturedAt;
     private final List<BusArrivalDto> busArrivalList;
 }

--- a/src/main/java/com/dku/council/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/dku/council/domain/ticket/controller/TicketController.java
@@ -18,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
@@ -27,6 +28,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TicketController {
 
+    private final Clock clock;
     private final TicketService ticketService;
     private final TicketEventService ticketEventService;
     private final CaptchaService captchaService;
@@ -117,7 +119,8 @@ public class TicketController {
     @UserAuth
     public ResponseTicketTurnDto enroll(AppAuthentication auth,
                                         @Valid @RequestBody RequestEnrollDto dto) {
-        Instant now = Instant.now();
+        Instant now = Instant.now(clock);
+
         captchaService.verifyCaptcha(dto.getCaptchaKey(), dto.getCaptchaValue());
         return ticketService.enroll(auth.getUserId(), dto.getEventId(), now);
     }

--- a/src/main/java/com/dku/council/domain/user/service/UserInfoService.java
+++ b/src/main/java/com/dku/council/domain/user/service/UserInfoService.java
@@ -15,12 +15,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.Instant;
 
 @Service
 @RequiredArgsConstructor
 public class UserInfoService {
 
+    private final Clock clock;
     private final UserRepository persistenceRepository;
     private final UserInfoMemoryRepository memoryRepository;
     private final CommentRepository commentRepository;
@@ -48,7 +50,7 @@ public class UserInfoService {
 
     @Transactional(readOnly = true)
     public UserInfo getUserInfo(Long userId) {
-        Instant now = Instant.now();
+        Instant now = Instant.now(clock);
         return memoryRepository.getUserInfo(userId, now)
                 .orElseGet(() -> {
                     User user = persistenceRepository.findByIdWithMajor(userId)
@@ -65,6 +67,6 @@ public class UserInfoService {
 
     public void cacheUserInfo(Long userId, User user) {
         UserInfo userInfo = new UserInfo(user);
-        memoryRepository.setUserInfo(userId, userInfo, Instant.now());
+        memoryRepository.setUserInfo(userId, userInfo, Instant.now(clock));
     }
 }

--- a/src/main/java/com/dku/council/global/config/jackson/JacksonDateTimeFormatter.java
+++ b/src/main/java/com/dku/council/global/config/jackson/JacksonDateTimeFormatter.java
@@ -1,11 +1,5 @@
 package com.dku.council.global.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
@@ -15,9 +9,6 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Component
@@ -37,27 +28,13 @@ public class JacksonDateTimeFormatter implements JacksonFormatConfigurer {
     @Override
     public void configure(Jackson2ObjectMapperBuilder builder) {
         builder.simpleDateFormat(DATE_TIME_FORMAT_PATTERN);
+
         builder.serializers(new LocalDateSerializer(DATE_FORMAT));
         builder.serializers(new LocalTimeSerializer(TIME_FORMAT));
         builder.serializers(new LocalDateTimeSerializer(DATE_TIME_FORMAT));
-        builder.serializerByType(ZonedDateTime.class, new JsonSerializer<ZonedDateTime>() {
-            @Override
-            public void serialize(ZonedDateTime zonedDateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
-                jsonGenerator.writeString(DATE_TIME_FORMAT.format(zonedDateTime));
-            }
-        });
+
         builder.deserializers(new LocalDateDeserializer(DATE_FORMAT));
         builder.deserializers(new LocalTimeDeserializer(TIME_FORMAT));
         builder.deserializers(new LocalDateTimeDeserializer(DATE_TIME_FORMAT));
-        builder.deserializerByType(ZonedDateTime.class, new JsonDeserializer<ZonedDateTime>() {
-            @Override
-            public ZonedDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-                return (ZonedDateTime) DATE_TIME_FORMAT.parse(p.readValueAs(String.class));
-            }
-        });
-    }
-
-    public static String serialize(LocalDateTime datetime) {
-        return DATE_TIME_FORMAT.format(datetime);
     }
 }

--- a/src/test/java/com/dku/council/domain/user/service/UserInfoServiceTest.java
+++ b/src/test/java/com/dku/council/domain/user/service/UserInfoServiceTest.java
@@ -12,13 +12,15 @@ import com.dku.council.domain.user.repository.UserRepository;
 import com.dku.council.global.error.exception.UserNotFoundException;
 import com.dku.council.mock.MajorMock;
 import com.dku.council.mock.UserMock;
+import com.dku.council.util.ClockUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
 import java.util.Optional;
 
 import static com.dku.council.domain.like.model.LikeTarget.POST;
@@ -31,6 +33,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserInfoServiceTest {
+
+    private final Clock clock = ClockUtil.create();
 
     @Mock
     private UserRepository persistenceRepository;
@@ -47,8 +51,12 @@ class UserInfoServiceTest {
     @Mock
     private UserInfoMemoryRepository memoryRepository;
 
-    @InjectMocks
     private UserInfoService service;
+
+    @BeforeEach
+    public void setup() {
+        this.service = new UserInfoService(clock, persistenceRepository, memoryRepository, commentRepository, likeService, postRepository);
+    }
 
 
     @Test


### PR DESCRIPTION
 - Bus API 가져올 때 timeout 추가 (실제로는 모든 webclient에 timeout 10초 추가)
 - 버스 capturedAt의 시간 기준을 UTC에서 Asia/Seoul로 변경